### PR TITLE
Forward read stream errors to joystick error event

### DIFF
--- a/src/joystick.js
+++ b/src/joystick.js
@@ -64,7 +64,8 @@ export class Joystick extends EventEmitter {
         this.mappingFn = options.mappingFn;
         this.includeInit = options.includeInit;
 
-        const fileStream = createReadStream(devicePath);
+        const fileStream = createReadStream(devicePath)
+            .on('error', e => this.emit('error', e));
         fileStream.pipe(new JoystickStream()).on('data', (b) => this.onData(b));
     }
 


### PR DESCRIPTION
This lets us handle errors that are caused by the read stream and prevent the process from crashing from unhandled error event.